### PR TITLE
OM-30 버튼 공용 컴포넌트 추가

### DIFF
--- a/src/components/button/Button.jsx
+++ b/src/components/button/Button.jsx
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+
+const StyledButton = styled.button`
+  cursor: pointer;
+  outline: 1px solid var(--Brown-40);
+  border-style: none;
+  border-radius: 8px;
+  background-color: var(--Brown-40);
+  padding: 12px 24px;
+  color: var(--Grayscale-10);
+
+  &:hover {
+    outline: 2px solid var(--Brown-40);
+  }
+
+  &:active {
+    outline: 2px solid var(--Brown-40);
+    background-color: var(--Brown-50);
+  }
+`;
+
+function Button({ className, children, onClick }) {
+  return (
+    <StyledButton className={className} onClick={onClick}>
+      {children}
+    </StyledButton>
+  );
+}
+
+export default Button;

--- a/src/components/button/FloatingButton.jsx
+++ b/src/components/button/FloatingButton.jsx
@@ -1,0 +1,19 @@
+const { styled } = require("styled-components");
+
+const StyledFloationButton = styled.button`
+  cursor: pointer;
+  border-radius: 200px;
+  background-color: var(--Brown-40);
+  padding: 12px 24px;
+  color: var(--Grayscale-10);
+`;
+
+function FloatingButton({ className, children, onClick }) {
+  return (
+    <StyledFloationButton className={className} onClick={onClick}>
+      {children}
+    </StyledFloationButton>
+  );
+}
+
+export default FloatingButton;


### PR DESCRIPTION
버튼 컴포넌트 두개 만들어뒀습니다. 
주로 쓰이는걸로 기본 스타일 설정은 해뒀는데 필요하면 부모 컴포넌트에서 스타일 줘서 덮어씌울 수 있습니다.

Button.jsx
- 배경색(--Brown-40)에 글자색(--Grayscale-10)의 박스모양 버튼

FloatingButton
-  배경색(--Brown-40)에 글자색(--Grayscale-10)의 둥근 모양 버튼