### PR TITLE
OM-39 useMediaQuery 훅 초기값 수정

### DIFF
--- a/src/hooks/useMediaQuery.js
+++ b/src/hooks/useMediaQuery.js
@@ -1,7 +1,7 @@
 import { useCallback, useState, useEffect } from "react";
 
 const useMediaQuery = (query) => {
-  const [matches, setMatches] = useState(false);
+  const [matches, setMatches] = useState(window.innerWidth <= 767);
 
   // 미디어 쿼리의 변경사항을 감지하고, matches 상태값을 변경함.
   const handleMediaQueryChange = useCallback(


### PR DESCRIPTION
- 모바일 환경에서 실행 시 isMobile 값이 항상 false 인 오류 수정
- matches의 초기값을 false 에서 window.innerWidth <= 767 로 수정
